### PR TITLE
商品編集 カテゴリにバリデーションがかからない不具合の修正

### DIFF
--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -31,7 +31,7 @@ $(function(){
   }
 
   $('#parent_category').on('change', function(){
-    var parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーの名前を取得
+    var parentCategory = document.getElementById('parent_category').value;
     if (parentCategory != "---"){
       $.ajax({
         url: '/get_category_children',

--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -1,9 +1,7 @@
 class GoodsController < ApplicationController
-  # before_action :move_to_index, except: [:index, :show]
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :category_index
   before_action :set_good, only: [:show, :edit, :update]
-  # before_action :set_message, only: [:show, :edit]
 
   def toppage
     @goods = Good.where(transaction_status_id: "1").order(created_at: "DESC").first(3)
@@ -115,7 +113,4 @@ class GoodsController < ApplicationController
     end
   end
 
-  # def set_message
-  #   @good = Good.find(params[:id])
-  # end
 end

--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -51,6 +51,7 @@ class GoodsController < ApplicationController
   end
 
   def update
+    @good.category_id = nil if good_params[:category_id] == nil
     if @good.update(good_params)
       redirect_to root_path
     else

--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -1,9 +1,9 @@
 class GoodsController < ApplicationController
-  before_action :move_to_index, except: [:index, :show]
+  # before_action :move_to_index, except: [:index, :show]
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :category_index
   before_action :set_good, only: [:show, :edit, :update]
-  before_action :set_message, only: [:show, :edit]
+  # before_action :set_message, only: [:show, :edit]
 
   def toppage
     @goods = Good.where(transaction_status_id: "1").order(created_at: "DESC").first(3)
@@ -20,7 +20,6 @@ class GoodsController < ApplicationController
     set_parent_category
   end
 
-
   def create
     @good = Good.new(good_params)
     @good.transaction_status_id = 1
@@ -34,7 +33,6 @@ class GoodsController < ApplicationController
       render :new
     end
   end
-
 
   def show
     @parents = Category.roots.all
@@ -117,7 +115,7 @@ class GoodsController < ApplicationController
     end
   end
 
-  def set_message
-    @good = Good.find(params[:id])
-  end
+  # def set_message
+  #   @good = Good.find(params[:id])
+  # end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_090512) do
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "image", null: false
+    t.string "image", null: false
     t.integer "good_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -71,8 +71,8 @@ ActiveRecord::Schema.define(version: 2020_05_15_090512) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
+    t.string "email", null: false
+    t.string "encrypted_password", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"


### PR DESCRIPTION
# What
カテゴリーを変更して、何も選択しなかった場合にバリデーションがかかるようにした。
good_paramsにcategory_idが見つからなかったとき、category_idにnilを代入するようにした。

# Why
カテゴリーを編集したときに空のカテゴリーでも元のカテゴリーが登録されてしまうことを防ぐため。