### PR TITLE
ユーザー新規登録機能のバグの修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   validates :nickname, presence: true
   validates :email, presence: true
   validates :password, presence: true
-  validates :uid, uniqueness: true
+  validates :uid, uniqueness: true, if: :provider?
   has_one :payment, dependent: :destroy
   has_one :address, dependent: :destroy
   has_one :identification, dependent: :destroy


### PR DESCRIPTION
## What
ユーザー新規登録をメールアドレスで行った場合にuidが無いことでバリデーションエラーとなってしまうバグが発生しました。
uidはSNSapiでのログインで使用されるものなので、メールアドレスでの新規登録時に当該バリデーションが機能しないようにモデルの記述を変更しました。

## Why
バグを修正しないとメールアドレスでのユーザー新規登録ができないため